### PR TITLE
Use sentry.Init for initialization

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -221,7 +221,7 @@ func New(dsn string, opts ...WriterOption) (*Writer, error) {
 		opt.apply(&cfg)
 	}
 
-	client, err := sentry.NewClient(sentry.ClientOptions{
+	err := sentry.Init(sentry.ClientOptions{
 		Dsn:          dsn,
 		SampleRate:   cfg.sampleRate,
 		Release:      cfg.release,
@@ -241,7 +241,7 @@ func New(dsn string, opts ...WriterOption) (*Writer, error) {
 	}
 
 	return &Writer{
-		client:       client,
+		client:       sentry.CurrentHub().Client(),
 		levels:       levels,
 		flushTimeout: cfg.flushTimeout,
 	}, nil


### PR DESCRIPTION
The Hub is now initialized and all sentry funcionality hooked on Hub does work as expected now.

Thanks for sharing this project btw, it helped a lot, this change will hopefuly make it even more customizable :)