### PR TITLE
use zerolog.LevelWriter interface for performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 ```go
 import (
 	"errors"
-	"io"
 	stdlog "log"
 	"os"
 
@@ -22,7 +21,8 @@ func main() {
 
 	defer w.Close()
 
-	logger := zerolog.New(io.MultiWriter(w, os.Stdout)).With().Timestamp().Logger()
+	multi := zerolog.MultiLevelWriter(os.Stdout, w)
+	logger := zerolog.New(multi).With().Timestamp().Logger()
 
 	logger.Error().Err(errors.New("dial timeout")).Msg("test message")
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -22,6 +22,9 @@ func TestParseLogEvent(t *testing.T) {
 
 	ev, ok := w.parseLogEvent(logEventJSON)
 	require.True(t, ok)
+	zLevel, err := w.parseLogLevel(logEventJSON)
+	assert.Nil(t, err)
+	ev.Level = levelsMapping[zLevel]
 
 	assert.Equal(t, ts, ev.Timestamp)
 	assert.Equal(t, sentry.LevelError, ev.Level)
@@ -54,5 +57,49 @@ func BenchmarkParseLogEvent_DisabledLevel(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		w.parseLogEvent(logEventJSON)
+	}
+}
+
+func BenchmarkWriteLogEvent(b *testing.B) {
+	w, err := New("")
+	if err != nil {
+		b.Errorf("failed to create writer: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, _ = w.Write(logEventJSON)
+	}
+}
+
+func BenchmarkWriteLogEvent_Disabled(b *testing.B) {
+	w, err := New("", WithLevels(zerolog.FatalLevel))
+	if err != nil {
+		b.Errorf("failed to create writer: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, _ = w.Write(logEventJSON)
+	}
+}
+
+func BenchmarkWriteLogLevelEvent(b *testing.B) {
+	w, err := New("")
+	if err != nil {
+		b.Errorf("failed to create writer: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, _ = w.WriteLevel(zerolog.ErrorLevel, logEventJSON)
+	}
+}
+
+func BenchmarkWriteLogLevelEvent_DisabledLevel(b *testing.B) {
+	w, err := New("", WithLevels(zerolog.FatalLevel))
+	if err != nil {
+		b.Errorf("failed to create writer: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, _ = w.WriteLevel(zerolog.ErrorLevel, logEventJSON)
 	}
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,6 +1,8 @@
 package zlogsentry
 
 import (
+	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -38,6 +40,125 @@ func TestParseLogEvent(t *testing.T) {
 	assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", ev.Extra["requestId"])
 }
 
+func TestParseLogLevel(t *testing.T) {
+	w, err := New("")
+	require.Nil(t, err)
+
+	level, err := w.parseLogLevel(logEventJSON)
+	require.Nil(t, err)
+	assert.Equal(t, zerolog.ErrorLevel, level)
+}
+
+func TestWrite(t *testing.T) {
+	beforeSendCalled := false
+	writer, err := New("", WithBeforeSend(func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		assert.Equal(t, sentry.LevelError, event.Level)
+		assert.Equal(t, "test message", event.Message)
+		require.Len(t, event.Exception, 1)
+		assert.Equal(t, "dial timeout", event.Exception[0].Value)
+		assert.True(t, time.Since(event.Timestamp).Minutes() < 1)
+		assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", event.Extra["requestId"])
+		beforeSendCalled = true
+		return event
+	}))
+	require.Nil(t, err)
+
+	var zerologError error
+	zerolog.ErrorHandler = func(err error) {
+		zerologError = err
+	}
+
+	// use io.MultiWriter to enforce using the Write() method
+	log := zerolog.New(io.MultiWriter(writer)).With().Timestamp().
+		Str("requestId", "bee07485-2485-4f64-99e1-d10165884ca7").
+		Logger()
+	log.Err(errors.New("dial timeout")).
+		Msg("test message")
+
+	require.Nil(t, zerologError)
+	require.True(t, beforeSendCalled)
+}
+
+func TestWriteLevel(t *testing.T) {
+	beforeSendCalled := false
+	writer, err := New("", WithBeforeSend(func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		assert.Equal(t, sentry.LevelError, event.Level)
+		assert.Equal(t, "test message", event.Message)
+		require.Len(t, event.Exception, 1)
+		assert.Equal(t, "dial timeout", event.Exception[0].Value)
+		assert.True(t, time.Since(event.Timestamp).Minutes() < 1)
+		assert.Equal(t, "bee07485-2485-4f64-99e1-d10165884ca7", event.Extra["requestId"])
+		beforeSendCalled = true
+		return event
+	}))
+	require.Nil(t, err)
+
+	var zerologError error
+	zerolog.ErrorHandler = func(err error) {
+		zerologError = err
+	}
+
+	log := zerolog.New(writer).With().Timestamp().
+		Str("requestId", "bee07485-2485-4f64-99e1-d10165884ca7").
+		Logger()
+	log.Err(errors.New("dial timeout")).
+		Msg("test message")
+
+	require.Nil(t, zerologError)
+	require.True(t, beforeSendCalled)
+}
+
+func TestWrite_Disabled(t *testing.T) {
+	beforeSendCalled := false
+	writer, err := New("",
+		WithLevels(zerolog.FatalLevel),
+		WithBeforeSend(func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			beforeSendCalled = true
+			return event
+		}))
+	require.Nil(t, err)
+
+	var zerologError error
+	zerolog.ErrorHandler = func(err error) {
+		zerologError = err
+	}
+
+	// use io.MultiWriter to enforce using the Write() method
+	log := zerolog.New(io.MultiWriter(writer)).With().Timestamp().
+		Str("requestId", "bee07485-2485-4f64-99e1-d10165884ca7").
+		Logger()
+	log.Err(errors.New("dial timeout")).
+		Msg("test message")
+
+	require.Nil(t, zerologError)
+	require.False(t, beforeSendCalled)
+}
+
+func TestWriteLevel_Disabled(t *testing.T) {
+	beforeSendCalled := false
+	writer, err := New("",
+		WithLevels(zerolog.FatalLevel),
+		WithBeforeSend(func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			beforeSendCalled = true
+			return event
+		}))
+	require.Nil(t, err)
+
+	var zerologError error
+	zerolog.ErrorHandler = func(err error) {
+		zerologError = err
+	}
+
+	log := zerolog.New(writer).With().Timestamp().
+		Str("requestId", "bee07485-2485-4f64-99e1-d10165884ca7").
+		Logger()
+	log.Err(errors.New("dial timeout")).
+		Msg("test message")
+
+	require.Nil(t, zerologError)
+	require.False(t, beforeSendCalled)
+}
+
 func BenchmarkParseLogEvent(b *testing.B) {
 	w, err := New("")
 	if err != nil {
@@ -49,7 +170,7 @@ func BenchmarkParseLogEvent(b *testing.B) {
 	}
 }
 
-func BenchmarkParseLogEvent_DisabledLevel(b *testing.B) {
+func BenchmarkParseLogEvent_Disabled(b *testing.B) {
 	w, err := New("", WithLevels(zerolog.FatalLevel))
 	if err != nil {
 		b.Errorf("failed to create writer: %v", err)
@@ -93,7 +214,7 @@ func BenchmarkWriteLogLevelEvent(b *testing.B) {
 	}
 }
 
-func BenchmarkWriteLogLevelEvent_DisabledLevel(b *testing.B) {
+func BenchmarkWriteLogLevelEvent_Disabled(b *testing.B) {
 	w, err := New("", WithLevels(zerolog.FatalLevel))
 	if err != nil {
 		b.Errorf("failed to create writer: %v", err)


### PR DESCRIPTION
If we log something (e.g. as local log level got set to debug) but we only want to send events for Error to sentry, each event is parsed to check for the log level.

As there is the LevelWriter interface as zerolog suggests for multiple outputs [here](https://github.com/rs/zerolog#multiple-log-output). That way we might skip parsing the event if the log level is disabled.

This PR implements this.

For reference I implemented benchmarks as well. This are the results on my device
```
# make benchmarks
[...]
pkg: github.com/archdx/zerolog-sentry
BenchmarkParseLogEvent-8                          272346              3806 ns/op            5136 B/op         14 allocs/op
BenchmarkParseLogEvent_DisabledLevel-8            253910              4014 ns/op            5136 B/op         14 allocs/op
BenchmarkWriteLogEvent-8                           65269             21795 ns/op           12586 B/op        109 allocs/op
BenchmarkWriteLogEvent_Disabled-8               20960934             57.01 ns/op               0 B/op          0 allocs/op
BenchmarkWriteLogLevelEvent-8                      68061             16895 ns/op           12618 B/op        109 allocs/op
BenchmarkWriteLogLevelEvent_DisabledLevel-8    167343889             6.876 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/archdx/zerolog-sentry        9.532s
```