### PR TITLE
Fixes a panic when Trace level log fired

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -67,8 +67,10 @@ func (w *Writer) Write(data []byte) (n int, err error) {
 	}
 
 	event, ok := w.parseLogEvent(data)
-	event.Level = levelsMapping[lvl]
-
+	if !ok {
+		return
+	}
+	event.Level, ok = levelsMapping[lvl]
 	if !ok {
 		return
 	}


### PR DESCRIPTION
This was a minor issue introduced in 3f53baa3c58d64eca2db6317a479a17fb27d8184 when Write is called with Trace level as Trace is not in the mapping.
Prior it would never get to trying to map trace as it was assumably never enabled.
The issue is minor, because Trace should not be enabled in most prod deployments, but still bit nasty :)

This assumes, that we do not want Trace to be added as Breadcrumb even if breadcrumbs are enabled, if that's incorrect assumption, we should add Trace to level mappings (probably mapped to Debug?)