### PR TITLE
Add breadcrumbs support for WriteLevel

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -91,19 +91,26 @@ func (w *Writer) Write(data []byte) (n int, err error) {
 // implements zerolog.LevelWriter
 func (w *Writer) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
 	n = len(p)
-	if _, enabled := w.levels[level]; !enabled {
+
+	event, ok := w.parseLogEvent(p)
+	if !ok {
+		return
+	}
+	event.Level, ok = levelsMapping[level]
+	if !ok {
 		return
 	}
 
-	event, ok := w.parseLogEvent(p)
-	event.Level = levelsMapping[level]
+	if _, enabled := w.levels[level]; !enabled {
+		// if the level is not enabled, add event as a breadcrumb
+		w.addBreadcrumb(event)
+		return
+	}
 
-	if ok {
-		w.hub.CaptureEvent(event)
-		// should flush before os.Exit
-		if event.Level == sentry.LevelFatal {
-			w.hub.Flush(w.flushTimeout)
-		}
+	w.hub.CaptureEvent(event)
+	// should flush before os.Exit
+	if event.Level == sentry.LevelFatal {
+		w.hub.Flush(w.flushTimeout)
 	}
 	return
 }


### PR DESCRIPTION
In 3f53baa3c58d64eca2db6317a479a17fb27d8184 we've added Breadcrumb support for Write function.
This makes sure we have the same for WriteLevel.