### PR TITLE
Set withBreadcrumbs when using NewWithHub

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -418,9 +418,10 @@ func NewWithHub(hub *sentry.Hub, opts ...WriterOption) (*Writer, error) {
 	}
 
 	return &Writer{
-		hub:          hub,
-		levels:       levels,
-		flushTimeout: cfg.flushTimeout,
+		hub:             hub,
+		levels:          levels,
+		flushTimeout:    cfg.flushTimeout,
+		withBreadcrumbs: cfg.breadcrumbs,
 	}, nil
 }
 


### PR DESCRIPTION
This should work:

```go
w, err := zlogsentry.NewWithHub(sentry.CurrentHub(), zlogsentry.WithBreadcrumbs())
```

But it needs `withBreadcrumbs` set on the writer.