### PR TITLE
optimize: if we do not need this level, do not need parseLogEvent

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -65,6 +65,10 @@ func (w *Writer) Write(data []byte) (n int, err error) {
 		return n, nil
 	}
 
+	if _, ok := levelsMapping[lvl]; !ok {
+		return
+	}
+
 	event, ok := w.parseLogEvent(data)
 	if !ok {
 		return


### PR DESCRIPTION
optimize: if we do not need this level, do not need parseLogEvent
